### PR TITLE
fix: check the session is null when call hasInvalidState

### DIFF
--- a/src/Providers/AbstractProvider.php
+++ b/src/Providers/AbstractProvider.php
@@ -407,6 +407,10 @@ abstract class AbstractProvider implements ProviderInterface
             return false;
         }
 
+        if (!$this->request->getSession()){
+            return false;    
+        }
+        
         $state = $this->request->getSession()->get('state');
 
         return !(strlen($state) > 0 && $this->request->get('state') === $state);


### PR DESCRIPTION
## I got this error in my laravel project:

``` php

Call to a member function get() on null {
"exception":"[object] (
Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): 
Call to a member function get() on null at 
/vendor/overtrue/socialite/src/Providers/AbstractProvider.php:410)
```